### PR TITLE
fix wrong logout message

### DIFF
--- a/application/views/auth/login.phtml
+++ b/application/views/auth/login.phtml
@@ -13,7 +13,7 @@
 
 <div id="vimbadmin-message-999" class="alert alert-success fade in">
     <a class="close" data-dismiss="alert" href="#">×</a>
-    There is no admin to assign to this domain.
+    You have been logged out.
 </div>
 
 {/if}


### PR DESCRIPTION
9b3a7e2497f42ea4e2ceeac8bc2f72ca1312097a looks like a verbatim
copy/paste from application/views/domain/admins.phtml
