### PR TITLE
Allow setting mailbox passwords using other crypt() algorithms, with random salt

### DIFF
--- a/application/configs/application.ini.dist
+++ b/application/configs/application.ini.dist
@@ -66,16 +66,20 @@ defaults.mailbox.min_password_length = 8
 
 ; The password hashing function to use. Set to one of:
 ;
-;   "plain"       - password stored as clear text 
-;   "md5"         - password hashed using MD5 without salt (PHP md5())
-;   "md5.salted"  - password hashed using MD5 with salt (see below)
-;   "crypt"       - standard DES hash (compatible with MySQL ENCRYPT and courier - be sure to
+;   "plain"          - password stored as clear text 
+;   "md5"            - password hashed using MD5 without salt (PHP md5())
+;   "md5.salted"     - password hashed using MD5 with salt (see below)
+;   "crypt"          - standard DES hash (compatible with MySQL ENCRYPT and courier - be sure to
 ;                      set a two character hash below
-;   "md5.crypt"   - MD5 based salted password hash nowadays commonly used in /etc/shadow. 
+;   "crypt:md5"      - standard MD5 hash with random seed
+;   "crypt:blowfish" - Blowfish hash with random seed (not in mainline glibc; added in some Linux distributions)
+;   "crypt:sha256"   - standard sha-256 hash (requires glibc 2.7 or newer). Equivalent to dovecot:SHA256-CRYPT
+;   "crypt:sha512"   - standard sha-512 hash (requires glibc 2.7 or newer). Equivalent to dovecot:SHA256-CRYPT
+;   "md5.crypt"      - MD5 based salted password hash nowadays commonly used in /etc/shadow. 
 ;                      (compatible with Dovecot) Requires min 8 character hash below.
-;   "sha1"        - password hashed using sha1 without salt
-;   "sha1.salted" - password hashed using sha1 with salt defined below 
-;   "dovecot:XXX" - call the Dovecot password generator (see next option below) and use the 
+;   "sha1"           - password hashed using sha1 without salt
+;   "sha1.salted"    - password hashed using sha1 with salt defined below 
+;   "dovecot:XXX"    - call the Dovecot password generator (see next option below) and use the 
 ;                      scheme specified by XXX. To see available schemes, use 'dovecotpw -l' 
 ;                      or 'doveadm pw -l'
 

--- a/application/models/Mailbox.php
+++ b/application/models/Mailbox.php
@@ -93,6 +93,35 @@ class Mailbox extends BaseMailbox
         {
             $this['password'] = ViMbAdmin_Dovecot::password( substr( $scheme, 8 ), $password, $this['username'] );
         }
+        else if ( substr( $scheme, 0, 6) == 'crypt:' )
+        {
+            $indicator = '';
+            $salt_len = 2;
+            switch ($scheme)
+            {
+              case 'crypt:md5':
+                  $salt_len = 8;
+                  $indicator = '$1$';
+                  break;
+              case 'crypt:blowfish':
+                  $salt_len = 22;
+                  $indicator = '$2a$';
+                  break;
+              case 'crypt:sha256':
+                  $salt_len = 16;
+                  $indicator = '$5$';
+                  break;
+              case 'crypt:sha512':
+                  $salt_len = 16;
+                  $indicator = '$6$';
+                  break;
+            }
+            $seedchars = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+            for ($i = 0; $i < $salt_len ; $i++) {
+                $salt .= $seedchars[rand(0, 63)];
+            }
+            $this['password'] = crypt( $password, $indicator . $salt );
+        }
         else
         {
             switch( $scheme )


### PR DESCRIPTION
Specify which algorithm to use via the existing defaults.mailbox.password_scheme
The following algorithms are supported:
    crypt:md5 ($1$, dovecot MD5-CRYPT)
    crypt:blowfish ($2a$ )
    crypt:sha256 ($5$, dovecot SHA256-CRYPT)
    crypt:sha512 ($6$, dovecot SHA512-CRYPT)

Borrowed some GPL3+ code from RoundCube:
https://github.com/roundcube/roundcubemail/blob/master/plugins/password/drivers/sql.php
