### PR TITLE
Fixed misspelled config option: mailbox_deletion_fs_enabled

### DIFF
--- a/application/configs/application.ini.dist
+++ b/application/configs/application.ini.dist
@@ -190,7 +190,7 @@ archive.path = "/srv/archives"
 ; See: https://github.com/opensolutions/ViMbAdmin/wiki/Deleting-Mailboxes
 ;
 
-mailbox_deletion_fs_enable = false
+mailbox_deletion_fs_enabled = false
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
"Delete the home directory and mailbox files also" checkbox didn't show up.
