### PR TITLE
Fix composer.json Smarty dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,9 +57,9 @@
     },
     "autoload": {
         "classmap": [
-            "vendor/smarty/smarty/distribution/libs/Smarty.class.php",
-            "vendor/smarty/smarty/distribution/libs/SmartyBC.class.php",
-            "vendor/smarty/smarty/distribution/libs/sysplugins/smarty_security.php"
+            "vendor/smarty/smarty/libs/Smarty.class.php",
+            "vendor/smarty/smarty/libs/SmartyBC.class.php",
+            "vendor/smarty/smarty/libs/sysplugins/smarty_security.php"
         ]
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
The Smarty version has been upgraded, fix with new link and paths.
