### PR TITLE
Add parentheses to the getDomain-call.

### DIFF
--- a/application/controllers/AliasController.php
+++ b/application/controllers/AliasController.php
@@ -262,7 +262,7 @@ class AliasController extends ViMbAdmin_Controller_PluginAction
 
                     // do we have available aliases?
                     if( !$this->getAdmin()->isSuper() && $this->getDomain()->getMaxaliases() != 0
-                            && $this->getDomain->getAliasCount() >= $this->getDomain()->getMaxAliases()
+                            && $this->getDomain()->getAliasCount() >= $this->getDomain()->getMaxAliases()
                         )
                     {
                         $this->addMessage( _( 'You have used all of your allocated aliases.' ), OSS_Message::ERROR );


### PR DESCRIPTION
If you want to add a alias as a domain admin the application crashes because the property getDomain does not exists.
