### PR TITLE
Support real domain aliases

### DIFF
--- a/application/controllers/AliasController.php
+++ b/application/controllers/AliasController.php
@@ -391,7 +391,7 @@ class AliasController extends ViMbAdmin_Controller_PluginAction
                     unset( $gotos[ $key ] );
                 else
                 {
-                    if( !Zend_Validate::is( $goto, 'EmailAddress', array( 1, null ) ) )
+                    if( substr( $goto, 0, 1 ) != '@' && !Zend_Validate::is( $goto, 'EmailAddress', array( 1, null ) ) )
                     {
                         $form->getElement( 'goto' )->addError( 'Invalid email address(es).' );
                         return false;

--- a/application/views/alias/form/add-edit.phtml
+++ b/application/views/alias/form/add-edit.phtml
@@ -22,7 +22,7 @@
                     <fieldset class="control-group" id="div-form-password">
                         <label for="local_part" class="control-label">
                                 Address
-                                <span class="label" id="address-popover" data-content="You can alias an entire domain by leaving the address field / local part blank." data-title="Domain Aliases" data-placement="left">?</span>
+                                <span class="label" id="address-popover" data-content="You can catch all unused addresses by leaving the address field / local part blank." data-title="Catch-all Aliases">?</span>
                         </label>
                         <div id="div-controls-{$element->local_part->getId()}" class="controls">
                             <div class="input-append btn-group" style="float: left;">
@@ -76,6 +76,7 @@
                 <fieldset class="control-group" id="div-form-goto">
                     <label for="goto" class="control-label">
                         {$element->goto->getLabel()}
+                        <span class="label" id="goto-popover" data-content="You can alias a address to another domain by leaving the local part empty (e.g. @example.com)." data-title="Domain Aliases">?</span>
                     </label>
                     <div class="controls" id="div-controls-goto">
                         <div class="input-append" id="goto-div-0">

--- a/application/views/alias/js/add.js
+++ b/application/views/alias/js/add.js
@@ -4,6 +4,7 @@ var gotoId = 1; // constantly increment it to make sure it is always unique on t
 $(document).ready( function()
 {
     $("#address-popover").popover( { trigger: 'hover' } );
+    $("#goto-popover").popover( { trigger: 'hover' } );
 
     $( '#goto_empty' ).keypress( function(e) {
         if( e.which == 13 )
@@ -61,7 +62,7 @@ function addGoto()
 
     if( address != '' )
     {
-        if( isValidEmail( address ) )
+        if( address.substr( 0, 1 ) == '@' && isValidEmailDomain( address.substr( 1 ) ) || isValidEmail( address ) )
         {
             if( gotoList.indexOf( address ) == -1 )
             {

--- a/public/css/920-style.css
+++ b/public/css/920-style.css
@@ -337,3 +337,11 @@ dl.inputs-list
     margin-left: 180px;
     margin-top: 5px;
 }
+
+.tab-content {
+  overflow: inherit;
+}
+
+.popover.right {
+  text-align: left !important;
+}

--- a/public/js/910-vimbadmin.functions.js
+++ b/public/js/910-vimbadmin.functions.js
@@ -223,3 +223,15 @@
     {
         return /^([A-Za-z0-9_\-\+\.])+\@([A-Za-z0-9_\-\.])+\.([A-Za-z]{2,4})$/.test( str );
     }
+
+
+    /**
+     * Checks if the value is a valid domain for email addresses or not.
+     *
+     * @param string str
+     * @return boolean
+     */
+    function isValidEmailDomain( str )
+    {
+        return /^([A-Za-z0-9_\-\.])+\.([A-Za-z]{2,4})$/.test( str );
+    }


### PR DESCRIPTION
Fixes #11

ViMbAdmin supports catch-all addresses, but doesn't support real domain aliases (rule "@example.com --> @example.net" redirects foo@example.com to foo@example.net). Pretty strange, because this can be achieved by simply allowing "@example.com" as goto of aliases. Postfix does the rest.

Fixes some popover styling issues, too.
