### PR TITLE
Mailbox auto aliases

### DIFF
--- a/application/Repositories/Alias.php
+++ b/application/Repositories/Alias.php
@@ -149,7 +149,7 @@ class Alias extends EntityRepository
                 ->setParameter( 1, $admin );
 
         if( $domain )
-            $qb->andWhere( 'm.Domain = ?2' )
+            $qb->andWhere( 'a.Domain = ?2' )
                 ->setParameter( 2, $domain );
 
         if( !$ima )

--- a/application/configs/application.ini.dist
+++ b/application/configs/application.ini.dist
@@ -379,8 +379,19 @@ vimbadmin_plugins.AccessPermissions.type.SIEVE = "SIEVE"
 
 
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Allow admins to force that for a mailbox/domain basic aliases are existing
+; If a new mailbox is created the system will check if the aliases are existing, if not they are created.
 
+vimbadmin_plugins.MailboxAutomaticAliases.disabled = false
 
+; These aliases should always exist, it is not recommened to delete it
+vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "postmaster"
+vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "abuse"
+
+; These aliases are optional, but it recommended to not remove them
+vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "hostmaster"
+vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "webmaster"
 
 
 

--- a/application/controllers/AliasController.php
+++ b/application/controllers/AliasController.php
@@ -318,17 +318,19 @@ class AliasController extends ViMbAdmin_Controller_PluginAction
 
         $status = $this->notify( 'alias', 'toggleActive', 'preToggle', $this, [ 'active' => $this->getAlias()->getActive() ] );
 
-        $this->getAlias()->setActive( !$this->getAlias()->getActive() );
-        $this->getAlias()->setModified( new \DateTime() );
+        if( $status == 'ok') {
+            $this->getAlias()->setActive( !$this->getAlias()->getActive() );
+            $this->getAlias()->setModified( new \DateTime() );
 
-        $this->log(
-            $this->getAlias()->getActive() ? \Entities\Log::ACTION_ALIAS_ACTIVATE : \Entities\Log::ACTION_ALIAS_DEACTIVATE,
-            "{$this->getAdmin()->getFormattedName()} " . ( $this->getAlias()->getActive() ? 'activated' : 'deactivated' ) . " alias {$this->getAlias()->getAddress()}"
-        );
-        $this->notify( 'alias', 'toggleActive', 'preflush', $this, [ 'active' => $this->getAlias()->getActive() ] );
-        $this->getD2EM()->flush();
-        $this->notify( 'alias', 'toggleActive', 'postflush', $this, [ 'active' => $this->getAlias()->getActive() ] );
-        print 'ok';
+            $this->log(
+                $this->getAlias()->getActive() ? \Entities\Log::ACTION_ALIAS_ACTIVATE : \Entities\Log::ACTION_ALIAS_DEACTIVATE,
+                "{$this->getAdmin()->getFormattedName()} " . ( $this->getAlias()->getActive() ? 'activated' : 'deactivated' ) . " alias {$this->getAlias()->getAddress()}"
+            );
+            $this->notify( 'alias', 'toggleActive', 'preflush', $this, [ 'active' => $this->getAlias()->getActive() ] );
+            $this->getD2EM()->flush();
+            $this->notify( 'alias', 'toggleActive', 'postflush', $this, [ 'active' => $this->getAlias()->getActive() ] );
+        }
+        print $status;
     }
 
 

--- a/application/controllers/AliasController.php
+++ b/application/controllers/AliasController.php
@@ -316,6 +316,8 @@ class AliasController extends ViMbAdmin_Controller_PluginAction
         if( !$this->getAlias() )
             print 'ko';
 
+        $status = $this->notify( 'alias', 'toggleActive', 'preToggle', $this, [ 'active' => $this->getAlias()->getActive() ] );
+
         $this->getAlias()->setActive( !$this->getAlias()->getActive() );
         $this->getAlias()->setModified( new \DateTime() );
 

--- a/application/controllers/AliasController.php
+++ b/application/controllers/AliasController.php
@@ -341,21 +341,22 @@ class AliasController extends ViMbAdmin_Controller_PluginAction
         foreach( $this->getAlias()->getPreferences() as $pref )
                 $this->getD2EM()->remove( $pref );
 
-        $this->notify( 'alias', 'delete', 'preRemove', $this );
-        $this->getD2EM()->remove( $this->getAlias() );
-        if( $this->getAlias()->getAddress() != $this->getAlias()->getGoto() )
-            $this->getDomain()->setAliasCount( $this->getDomain()->getAliasCount() - 1 );
+        if($this->notify( 'alias', 'delete', 'preRemove', $this )) {
+            $this->getD2EM()->remove( $this->getAlias() );
+            if( $this->getAlias()->getAddress() != $this->getAlias()->getGoto() )
+                $this->getDomain()->setAliasCount( $this->getDomain()->getAliasCount() - 1 );
 
-        $this->log(
-            \Entities\Log::ACTION_ALIAS_DELETE,
-            "{$this->getAdmin()->getFormattedName()} removed alias {$this->getAlias()->getAddress()}"
-        );
+            $this->log(
+                \Entities\Log::ACTION_ALIAS_DELETE,
+                "{$this->getAdmin()->getFormattedName()} removed alias {$this->getAlias()->getAddress()}"
+            );
 
-        $this->notify( 'alias', 'delete', 'preFlush', $this );
-        $this->getD2EM()->flush();
-        $this->notify( 'alias', 'delete', 'postFlush', $this );
+            $this->notify( 'alias', 'delete', 'preFlush', $this );
+            $this->getD2EM()->flush();
+            $this->notify( 'alias', 'delete', 'postFlush', $this );
 
-        $this->addMessage( 'Alias has bean removed successfully', OSS_Message::SUCCESS );
+            $this->addMessage( 'Alias has bean removed successfully', OSS_Message::SUCCESS );
+        }
         $this->redirect( 'alias/list' );
     }
 

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2014 Matthias Fechner
+ * @license http://opensource.org/licenses/gpl-3.0.html GNU General Public License, version 3 (GPLv3)
+ * @author Matthias Fechner <matthias _at_ fechner.net>
+ */
+
+/**
+ * The Mailbox Automatic Aliases Plugin
+ * 
+ * The plugin ensures that a required set of aliases for a domain are existent.
+ * Required aliases are:
+ *   postmaster@domain.tld
+ *   abuse@domain.tld
+ * Optional aliases are:
+ *   webmaster@domain.tld
+ *   hostmaster@domains.tld
+ *   
+ * See https://github.com/idefix6/vimbadmin-mailbox-automatic-aliases
+ *
+ * Add the following lines to configs/application.ini:
+ * vimbadmin_plugins.MailboxAutomaticAliases.disabled = false
+ * vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "postmaster"
+ * vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "abuse"
+ * vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "hostmaster"
+ * vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "webmaster"
+ *
+ * @package ViMbAdmin
+ * @subpackage Plugins
+ */
+ class ViMbAdminPlugin_MailboxAutomaticAliases extends ViMbAdmin_Plugin implements OSS_Plugin_Observer {
+    private $defaultAliases;
+     
+     public function __construct(OSS_Controller_Action $controller) {
+         parent::__construct($controller, get_class() );
+
+         // read config parameters
+         $this->defaultAliases = $controller->getOptions()['vimbadmin_plugins']['MailboxAutomaticAliases']['defaultAliases'];
+     }
+     
+     public function mailbox_add_addPostflush($controller, $options) {
+         // get domain
+         $domainId = $controller->getDomain()->getId();
+         $domain = $controller->getDomain()->getDomain();
+
+         // get mailbox
+         $mailbox = $controller->getMailbox()->getUsername();
+
+         // check if domain has enforced aliases or do we have to create them?
+         if($this->defaultAliases) {
+             foreach($this->defaultAliases as $key => $item) {
+                 $aliasList = $controller->getD2EM()->getRepository( "\\Entities\\Alias" )->filterForAliasList( $item . '@' . $domain, $controller->getAdmin(), $domainId, true );
+                 if(count($aliasList) == 0) {
+                     $alias = new \Entities\Alias();
+                     $alias->setAddress($item.'@'.$domain);
+                     $alias->setGoto($mailbox);
+                     $alias->setDomain($controller->getDomain());
+                     $alias->setActive(1);
+                     $alias->setCreated(new \DateTime());
+                     $controller->getD2EM()->persist($alias);
+                     // Increase alias count for domain
+                     $controller->getDomain()->increaseAliasCount();
+                     $controller->getD2EM()->flush();
+                     $controller->addMessage( sprintf(_("Auto-Created alias %s@%s -> %s."), $item, $domain, $mailbox));
+                 }
+             }
+         }
+     }
+ }

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -98,4 +98,24 @@
          }
          return true;
      }
+
+     public function alias_toggleActive_preToggle($controller, $options) {
+         // get alias that should be deleted
+         $alias = $controller->getAlias()->getAddress();
+         $domain = $controller->getDomain()->getDomain();
+
+         if($options['active'] == 'true') {
+             // we have to check if it is allowed to disable this alias
+             if($this->defaultAliases) {
+                 foreach($this->defaultAliases as $key => $item) {
+                     if($alias == $item.'@'.$domain) {
+                         // not allowed to delete, show error message and stop delete
+                         return( sprintf( _("Alias %s is required and cannot be disabled."), $alias));
+                     }
+                 }
+             }
+
+         }
+        return 'ok';
+     }
  }

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -38,7 +38,13 @@
          // read config parameters
          $this->defaultAliases = $controller->getOptions()['vimbadmin_plugins']['MailboxAutomaticAliases']['defaultAliases'];
      }
-     
+
+     /**
+      * Is called after a mailbox is created. It ensures that required aliases are created.
+      *
+      * @param $controller
+      * @param $options
+      */
      public function mailbox_add_addPostflush($controller, $options) {
          // get domain
          $domainId = $controller->getDomain()->getId();
@@ -66,5 +72,30 @@
                  }
              }
          }
+     }
+
+     /**
+      * Check if the aliases is allowed to be removed. If not return false, else return true.
+      *
+      * @param $controller
+      * @param $options
+      * @return bool
+      */
+     public function alias_delete_preRemove($controller, $options) {
+         // get alias that should be deleted
+         $alias = $controller->getAlias()->getAddress();
+         $domain = $controller->getDomain()->getDomain();
+
+         // check if the alias to delete is not enforced by the plugin
+         if($this->defaultAliases) {
+             foreach($this->defaultAliases as $key => $item) {
+                 if($alias == $item.'@'.$domain) {
+                     // not allowed to delete, show error message and stop delete
+                     $controller->addMessage( sprintf( _("Alias %s is required and cannot be deleted."), $alias), OSS_Message::ERROR);
+                     return false;
+                 }
+             }
+         }
+         return true;
      }
  }

--- a/library/ViMbAdmin/Controller/PluginAction.php
+++ b/library/ViMbAdmin/Controller/PluginAction.php
@@ -172,6 +172,9 @@ class ViMbAdmin_Controller_PluginAction extends ViMbAdmin_Controller_Action impl
             if(!$status) {
                 $returnValue=false;
             }
+            if($hook == 'preToggle') {
+                $returnValue=$status;
+            }
         }
         return($returnValue);
     }

--- a/library/ViMbAdmin/Controller/PluginAction.php
+++ b/library/ViMbAdmin/Controller/PluginAction.php
@@ -166,8 +166,14 @@ class ViMbAdmin_Controller_PluginAction extends ViMbAdmin_Controller_Action impl
      */
     public function notify( $controller, $action, $hook, OSS_Controller_Action $controllerObject, $params = null )
     {
-        foreach( $this->observers as $o )
-            $o->update( $controller, $action, $hook, $controllerObject, $params );
+        $returnValue=true;
+        foreach( $this->observers as $o ) {
+            $status=$o->update( $controller, $action, $hook, $controllerObject, $params );
+            if(!$status) {
+                $returnValue=false;
+            }
+        }
+        return($returnValue);
     }
     
     /**

--- a/library/ViMbAdmin/Plugin.php
+++ b/library/ViMbAdmin/Plugin.php
@@ -70,6 +70,7 @@ class ViMbAdmin_Plugin
         $hookfn = "{$controller}_{$action}_{$hook}";
         if( method_exists( $this, $hookfn ) )
             return $this->$hookfn( $controllerObject, $params );
+        return true;
     }
 
 


### PR DESCRIPTION
This plugin enable a feature to automatically create aliases defined in application.ini.
There are some standard aliases that must always exist and a standard user is not aware of the fact that e.g. postmaster@domain must exist. The alias abuse@domain should exist, if not it is possible that your domain will get into a spam blacklist.
This plugin ensures that also a not skilled user as always the required aliases active.