### PR TITLE
updated max password length to 255

### DIFF
--- a/library/ViMbAdmin/Form/Admin/ChangePassword.php
+++ b/library/ViMbAdmin/Form/Admin/ChangePassword.php
@@ -54,7 +54,7 @@ class ViMbAdmin_Form_Admin_ChangePassword extends ViMbAdmin_Form
             ->setAttrib( 'size', 20)
             ->setRequired( true )
             ->addValidator( 'NotEmpty', true )
-            ->addValidator( 'StringLength', true, array( 8, 32 ) )
+            ->addValidator( 'StringLength', true, array( 8, 255 ) )
             ->addFilter( 'StripSlashes' );
 
         $password = $this
@@ -64,7 +64,7 @@ class ViMbAdmin_Form_Admin_ChangePassword extends ViMbAdmin_Form
             ->setAttrib( 'size', 20)
             ->setRequired( true )
             ->addValidator( 'NotEmpty', true )
-            ->addValidator( 'StringLength', true, array( 8, 32 ) )
+            ->addValidator( 'StringLength', true, array( 8, 255 ) )
             ->addFilter( 'StripSlashes' );
 
         $confirmPassword = $this

--- a/library/ViMbAdmin/Form/Admin/Password.php
+++ b/library/ViMbAdmin/Form/Admin/Password.php
@@ -63,7 +63,7 @@ class ViMbAdmin_Form_Admin_Password extends ViMbAdmin_Form
             ->setAttrib( 'autocomplete', 'off' )
             ->setRequired( true )
             ->addValidator( 'NotEmpty', true )
-            ->addValidator( 'StringLength', false, array( $this->minPasswordLength, 40 ) )
+            ->addValidator( 'StringLength', false, array( $this->minPasswordLength, 255 ) )
             ->addFilter( 'StringTrim' )
             ->addFilter( 'HtmlEntitiesDecode' )
             ->addFilter( 'StripSlashes' );

--- a/library/ViMbAdmin/Form/Mailbox/AddEdit.php
+++ b/library/ViMbAdmin/Form/Mailbox/AddEdit.php
@@ -96,7 +96,7 @@ class ViMbAdmin_Form_Mailbox_AddEdit extends ViMbAdmin_Form
             ->setAttrib( 'size', 40 )
             ->setRequired( true )
             ->addValidator( 'NotEmpty', true )
-            ->addValidator( 'StringLength', true, array( $this->getMinPasswordLength(), 32 ) )
+            ->addValidator( 'StringLength', true, array( $this->getMinPasswordLength(), 255 ) )
             ->addFilter( 'StringTrim' )
             ->addFilter( 'HtmlEntitiesDecode' )
             ->addFilter( 'StripSlashes' );

--- a/library/ViMbAdmin/Form/Mailbox/Password.php
+++ b/library/ViMbAdmin/Form/Mailbox/Password.php
@@ -74,7 +74,7 @@ class ViMbAdmin_Form_Mailbox_Password extends ViMbAdmin_Form
             ->setAttrib( 'class', 'required' )
             ->setRequired( true )
             ->addValidator( 'NotEmpty', true )
-            ->addValidator( 'StringLength', true, array( $this->getMinPasswordLength(), 32 ) )
+            ->addValidator( 'StringLength', true, array( $this->getMinPasswordLength(), 255 ) )
             ->addFilter( 'StringTrim' )
             ->addFilter( 'HtmlEntitiesDecode' )
             ->addFilter( 'StripSlashes' );
@@ -85,7 +85,7 @@ class ViMbAdmin_Form_Mailbox_Password extends ViMbAdmin_Form
             ->setAttrib( 'class', 'required' )
             ->setRequired( true )
             ->addValidator( 'NotEmpty', true )
-            ->addValidator( 'StringLength', true, array( $this->getMinPasswordLength(), 32 ) )
+            ->addValidator( 'StringLength', true, array( $this->getMinPasswordLength(), 255 ) )
             ->addFilter( 'StringTrim' )
             ->addFilter( 'HtmlEntitiesDecode' )
             ->addFilter( 'StripSlashes' );


### PR DESCRIPTION
password limits are not necessary, due to the fact that the password will be hashed before storing.  the length of 255 chars should be long enough for every user and it fits in the password field if any crazy admin wants to store them in plain text. if the application ensures that passwords can not be stored in plain text, the limit can be removed.