### PR TITLE
Hook rewrite return value

### DIFF
--- a/application/controllers/AliasController.php
+++ b/application/controllers/AliasController.php
@@ -316,17 +316,21 @@ class AliasController extends ViMbAdmin_Controller_PluginAction
         if( !$this->getAlias() )
             print 'ko';
 
-        $this->getAlias()->setActive( !$this->getAlias()->getActive() );
-        $this->getAlias()->setModified( new \DateTime() );
+        $status = 'ok';
 
-        $this->log(
-            $this->getAlias()->getActive() ? \Entities\Log::ACTION_ALIAS_ACTIVATE : \Entities\Log::ACTION_ALIAS_DEACTIVATE,
-            "{$this->getAdmin()->getFormattedName()} " . ( $this->getAlias()->getActive() ? 'activated' : 'deactivated' ) . " alias {$this->getAlias()->getAddress()}"
-        );
-        $this->notify( 'alias', 'toggleActive', 'preflush', $this, [ 'active' => $this->getAlias()->getActive() ] );
-        $this->getD2EM()->flush();
-        $this->notify( 'alias', 'toggleActive', 'postflush', $this, [ 'active' => $this->getAlias()->getActive() ] );
-        print 'ok';
+        if( $status == 'ok') {
+            $this->getAlias()->setActive( !$this->getAlias()->getActive() );
+            $this->getAlias()->setModified( new \DateTime() );
+
+            $this->log(
+                $this->getAlias()->getActive() ? \Entities\Log::ACTION_ALIAS_ACTIVATE : \Entities\Log::ACTION_ALIAS_DEACTIVATE,
+                "{$this->getAdmin()->getFormattedName()} " . ( $this->getAlias()->getActive() ? 'activated' : 'deactivated' ) . " alias {$this->getAlias()->getAddress()}"
+            );
+            $this->notify( 'alias', 'toggleActive', 'preflush', $this, [ 'active' => $this->getAlias()->getActive() ] );
+            $this->getD2EM()->flush();
+            $this->notify( 'alias', 'toggleActive', 'postflush', $this, [ 'active' => $this->getAlias()->getActive() ] );
+        }
+        print $status;
     }
 
 

--- a/application/controllers/AliasController.php
+++ b/application/controllers/AliasController.php
@@ -341,21 +341,22 @@ class AliasController extends ViMbAdmin_Controller_PluginAction
         foreach( $this->getAlias()->getPreferences() as $pref )
                 $this->getD2EM()->remove( $pref );
 
-        $this->notify( 'alias', 'delete', 'preRemove', $this );
-        $this->getD2EM()->remove( $this->getAlias() );
-        if( $this->getAlias()->getAddress() != $this->getAlias()->getGoto() )
-            $this->getDomain()->setAliasCount( $this->getDomain()->getAliasCount() - 1 );
+        if($this->notify( 'alias', 'delete', 'preRemove', $this )) {
+            $this->getD2EM()->remove( $this->getAlias() );
+            if( $this->getAlias()->getAddress() != $this->getAlias()->getGoto() )
+                $this->getDomain()->setAliasCount( $this->getDomain()->getAliasCount() - 1 );
 
-        $this->log(
-            \Entities\Log::ACTION_ALIAS_DELETE,
-            "{$this->getAdmin()->getFormattedName()} removed alias {$this->getAlias()->getAddress()}"
-        );
+            $this->log(
+                \Entities\Log::ACTION_ALIAS_DELETE,
+                "{$this->getAdmin()->getFormattedName()} removed alias {$this->getAlias()->getAddress()}"
+            );
 
-        $this->notify( 'alias', 'delete', 'preFlush', $this );
-        $this->getD2EM()->flush();
-        $this->notify( 'alias', 'delete', 'postFlush', $this );
+            $this->notify( 'alias', 'delete', 'preFlush', $this );
+            $this->getD2EM()->flush();
+            $this->notify( 'alias', 'delete', 'postFlush', $this );
 
-        $this->addMessage( 'Alias has bean removed successfully', OSS_Message::SUCCESS );
+            $this->addMessage( 'Alias has bean removed successfully', OSS_Message::SUCCESS );
+        }
         $this->redirect( 'alias/list' );
     }
 

--- a/library/ViMbAdmin/Controller/PluginAction.php
+++ b/library/ViMbAdmin/Controller/PluginAction.php
@@ -166,8 +166,14 @@ class ViMbAdmin_Controller_PluginAction extends ViMbAdmin_Controller_Action impl
      */
     public function notify( $controller, $action, $hook, OSS_Controller_Action $controllerObject, $params = null )
     {
-        foreach( $this->observers as $o )
-            $o->update( $controller, $action, $hook, $controllerObject, $params );
+        $returnValue=true;
+        foreach( $this->observers as $o ) {
+            $status=$o->update( $controller, $action, $hook, $controllerObject, $params );
+            if(!$status) {
+                $returnValue=false;
+            }
+        }
+        return($returnValue);
     }
     
     /**

--- a/library/ViMbAdmin/Plugin.php
+++ b/library/ViMbAdmin/Plugin.php
@@ -70,6 +70,7 @@ class ViMbAdmin_Plugin
         $hookfn = "{$controller}_{$action}_{$hook}";
         if( method_exists( $this, $hookfn ) )
             return $this->$hookfn( $controllerObject, $params );
+        return true;
     }
 
 


### PR DESCRIPTION
I required the functionality to implement checks in plugins.
These checks must be able to forbid core to write values into the database.
As this logic is part of the plugin the hook system must be able to handle return values.

With these modifications the called hooks can return a false value and therefor are able to inform core to not execute the triggered action, but display an error message.

Would be nice if this could be merged into the repository.
