### PR TITLE
disable autocompletion on password formfields. fixes #103 and fixes #144.

### DIFF
--- a/library/ViMbAdmin/Form/Admin/AddEdit.php
+++ b/library/ViMbAdmin/Form/Admin/AddEdit.php
@@ -64,7 +64,8 @@ class ViMbAdmin_Form_Admin_AddEdit extends ViMbAdmin_Form
         $username->addValidator( new OSS_Validate_OSSDoctrine2Uniqueness( array( 'entity' => '\\Entities\\Admin', 'property' => 'username' ) ), true );
 
         $password = OSS_Form_Auth::createPasswordElement();
-        
+        $password->setAttrib( 'autocomplete', 'off' );
+
         $active = $this->createElement( 'checkbox', 'active' )
             ->setLabel( _( 'Active' ) )
             ->addValidator( 'InArray', false, array( array( 0, 1 ) ) )

--- a/library/ViMbAdmin/Form/Mailbox/AddEdit.php
+++ b/library/ViMbAdmin/Form/Mailbox/AddEdit.php
@@ -94,6 +94,7 @@ class ViMbAdmin_Form_Mailbox_AddEdit extends ViMbAdmin_Form
             ->setLabel( _( 'Password' ) )
             ->setAttrib( 'title', _( 'Password' ) )
             ->setAttrib( 'size', 40 )
+            ->setAttrib( 'autocomplete', 'off' )
             ->setRequired( true )
             ->addValidator( 'NotEmpty', true )
             ->addValidator( 'StringLength', true, array( $this->getMinPasswordLength(), 255 ) )


### PR DESCRIPTION
This is no perfect solution as the autocomplete element is not part of the html standard, but it is available in most common browsers.