### PR TITLE
Fix mail config typo in sample config

### DIFF
--- a/application/configs/application.ini.dist
+++ b/application/configs/application.ini.dist
@@ -287,14 +287,20 @@ server.email.address = "support@example.com"
 ;; See: http://framework.zend.com/manual/en/zend.mail.smtp-authentication.html
 ;;
 ;; Ensure you have a working mail server configuration so the system can
-;; send emails:
+;; send emails.
+;; Possible values:
+;; transport.type: sendmail, smtp
+;; transport.auth: crammd5, login, plain
+;; transport.ssl: ssl, tls
 ;;
-resources.mailer.smtphost = "localhost"
-;resources.mailer.username = ""
-;resources.mailer.password = ""
-;resources.mailer.auth     = ""
-;resources.mailer.ssl      = ""
-;resources.mailer.port     = "25"
+
+resources.mail.transport.type = smtp
+resources.mail.transport.host = "localhost"
+;resources.mail.transport.username = ""
+;resources.mail.transport.password = ""
+;resources.mail.transport.auth = ""
+;resources.mail.transport.ssl = ""
+;resources.mail.transport.port = "25"
 
 
 


### PR DESCRIPTION
For Zend Framework the mail resource is actually configured through resources.mail.transport, not resources.mailer.
Replace the misleading sample configuration with correct examples.
With the erroneous configuration mails would not be sent if the underlying mailserver does strict HELO checks (i.e. reject mails with HELO localhost), leading to error messages about mails not being able to be sent.

This might help fix bug reports such as #25