### PR TITLE
Fix #168 Vimbadmin installation issue due to composer.json over secure http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,16 +28,12 @@
             "type": "package",
             "package": {
                 "name": "smarty/smarty",
-                "version": "3.1.18",
-                "dist": {
-                    "url": "http://www.smarty.net/files/Smarty-3.1.18.zip",
-                    "type": "zip"
-                },
+                "version": "dev-master",
                 "source": {
-                    "url": "http://smarty-php.googlecode.com/svn/",
-                    "type": "svn",
-                    "reference": "tags/v3.1.18/distribution/"
-                }
+                  "type": "git",
+                  "url": "https://github.com/smarty-php/smarty.git",
+                  "reference": "master"
+        }
             }
         }
     ],
@@ -46,7 +42,7 @@
         "doctrine/orm": "2.4.*",
         "opensolutions/oss-framework": "dev-master",
         "zendframework/zendframework1": "~1.12",
-        "smarty/smarty": "3.1.18",
+        "smarty/smarty": "3.1.*",
         "opensolutions/minify": "1.*",
         "komola/bootstrap-zend-framework": "dev-master"
     },


### PR DESCRIPTION
Fixed. 

For reference: https://github.com/opensolutions/ViMbAdmin/issues/168

```
Command Error: Loading composer repositories with package information
Installing dependencies                                          
  - Installing zendframework/zendframework1 (dev-master fccf5d2)
    Downloading: 100%         

  - Installing opensolutions/oss-framework (dev-master 53dc6d8)
    Downloading: 100%         

  - Installing opensolutions/minify (1.0.0)
    Downloading: 100%         

  - Installing symfony/polyfill-mbstring (dev-master 1289d16)
    Downloading: 100%         

  - Installing symfony/console (2.8.x-dev c25e035)
    Downloading: 100%         

  - Installing doctrine/lexer (dev-master 83893c5)
    Downloading: 100%         

  - Installing doctrine/annotations (dev-master 07a9af2)
    Downloading: 100%         

  - Installing doctrine/collections (dev-master 866e100)
    Downloading: 100%         

  - Installing doctrine/cache (dev-master e0ef9e9)
    Downloading: 100%         

  - Installing doctrine/inflector (dev-master 90b2128)
    Downloading: 100%         

  - Installing doctrine/common (dev-master 773c56e)
    Downloading: 100%         

  - Installing doctrine/dbal (dev-master 61e1f86)
    Downloading: 100%         

  - Installing doctrine/orm (2.4.x-dev ea713a0)
    Downloading: 100%         

  - Installing smarty/smarty (dev-master d88168d)
    Downloading: 100%         

  - Installing komola/bootstrap-zend-framework (dev-master f81b60c)
    Downloading: 100%         

Writing lock file
Generating autoload files
```