### PR TITLE
Mailbox auto aliases

### DIFF
--- a/application/configs/application.ini.dist
+++ b/application/configs/application.ini.dist
@@ -409,7 +409,11 @@ vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "abuse"
 vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "hostmaster"
 vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "webmaster"
 
-
+; Define this if emails should be forwarded to a fixed address instead of the first mailbox address of the domain
+;vimbadmin_plugins.MailboxAutomaticAliases.defaultMapping.postmaster = "postmaster@example.net"
+;vimbadmin_plugins.MailboxAutomaticAliases.defaultMapping.abuse = "abuse@example.net"
+;vimbadmin_plugins.MailboxAutomaticAliases.defaultMapping.hostmaster = "hostmaster@example.net"
+;vimbadmin_plugins.MailboxAutomaticAliases.defaultMapping.webmaster = "webmaster@example.net"
 
 
 

--- a/application/configs/application.ini.dist
+++ b/application/configs/application.ini.dist
@@ -395,8 +395,19 @@ vimbadmin_plugins.AccessPermissions.type.SIEVE = "SIEVE"
 
 
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Allow admins to force that for a mailbox/domain basic aliases are existing
+; If a new mailbox is created the system will check if the aliases are existing, if not they are created.
 
+vimbadmin_plugins.MailboxAutomaticAliases.disabled = false
 
+; These aliases should always exist, it is not recommened to delete it
+vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "postmaster"
+vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "abuse"
+
+; These aliases are optional, but it recommended to not remove them
+vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "hostmaster"
+vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "webmaster"
 
 
 

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2014 Matthias Fechner
+ * @license http://opensource.org/licenses/gpl-3.0.html GNU General Public License, version 3 (GPLv3)
+ * @author Matthias Fechner <matthias _at_ fechner.net>
+ */
+
+/**
+ * The Mailbox Automatic Aliases Plugin
+ * 
+ * The plugin ensures that a required set of aliases for a domain are existent.
+ * Required aliases are:
+ *   postmaster@domain.tld
+ *   abuse@domain.tld
+ * Optional aliases are:
+ *   webmaster@domain.tld
+ *   hostmaster@domains.tld
+ *   
+ * See https://github.com/idefix6/vimbadmin-mailbox-automatic-aliases
+ *
+ * Add the following lines to configs/application.ini:
+ * vimbadmin_plugins.MailboxAutomaticAliases.disabled = false
+ * vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "postmaster"
+ * vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "abuse"
+ * vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "hostmaster"
+ * vimbadmin_plugins.MailboxAutomaticAliases.defaultAliases[] = "webmaster"
+ *
+ * @package ViMbAdmin
+ * @subpackage Plugins
+ */
+ class ViMbAdminPlugin_MailboxAutomaticAliases extends ViMbAdmin_Plugin implements OSS_Plugin_Observer {
+    private $defaultAliases;
+     
+     public function __construct(OSS_Controller_Action $controller) {
+         parent::__construct($controller, get_class() );
+
+         // read config parameters
+         $this->defaultAliases = $controller->getOptions()['vimbadmin_plugins']['MailboxAutomaticAliases']['defaultAliases'];
+     }
+     
+     public function mailbox_add_addPostflush($controller, $options) {
+         // get domain
+         $domainId = $controller->getDomain()->getId();
+         $domain = $controller->getDomain()->getDomain();
+
+         // get mailbox
+         $mailbox = $controller->getMailbox()->getUsername();
+
+         // check if domain has enforced aliases or do we have to create them?
+         if($this->defaultAliases) {
+             foreach($this->defaultAliases as $key => $item) {
+                 $aliasList = $controller->getD2EM()->getRepository( "\\Entities\\Alias" )->filterForAliasList( $item . '@' . $domain, $controller->getAdmin(), $domainId, true );
+                 if(count($aliasList) == 0) {
+                     $alias = new \Entities\Alias();
+                     $alias->setAddress($item.'@'.$domain);
+                     $alias->setGoto($mailbox);
+                     $alias->setDomain($controller->getDomain());
+                     $alias->setActive(1);
+                     $alias->setCreated(new \DateTime());
+                     $controller->getD2EM()->persist($alias);
+                     // Increase alias count for domain
+                     $controller->getDomain()->increaseAliasCount();
+                     $controller->getD2EM()->flush();
+                     $controller->addMessage( sprintf(_("Auto-Created alias %s@%s -> %s."), $item, $domain, $mailbox));
+                 }
+             }
+         }
+     }
+ }

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -110,13 +110,14 @@
                  foreach($this->defaultAliases as $key => $item) {
                      if($alias == $item.'@'.$domain) {
                          // not allowed to delete, show error message and stop delete
-                         return( sprintf( _("Alias %s is required and cannot be disabled."), $alias));
+                         print( sprintf( _("Alias %s is required and cannot be disabled."), $alias));
+                         exit(0);
                      }
                  }
              }
 
          }
-        return 'ok';
+        return true;
      }
 
      /**

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -164,4 +164,26 @@
              }
          }
      }
+
+     /**
+      * Check that a mailbox cannot be removed if used as administrative destination mailbox
+      *
+      */
+     public function mailbox_purge_preRemove($controller, $options) {
+         /*  check if mailbox is not an administrative mailbox */
+         $mailbox = $controller->getMailbox()->getUserName();
+
+         if($this->defaultMapping) {
+             foreach($this->defaultMapping as $key => $item) {
+                 if($mailbox == $item) {
+                     // not allowed to delete, show error message and stop delete
+                     $controller->addMessage( sprintf( _("Mailbox %s is defined as automatic alias to fullfill <a href=\"https://www.ietf.org/rfc/rfc2142.txt\" target=\"page\">RFC2142</a>. If you want to remove it, update you application.ini file first. Check key vimbadmin_plugins.MailboxAutomaticAliases.defaultMapping."), $mailbox), OSS_Message::ERROR);
+                     //print( sprintf( _("Mailbox %s is defined as automatic alias to fullfill <a href=\"https://www.ietf.org/rfc/rfc2142.txt\" target=\"page\">RFC2142</a>. If you want to remove it, update you application.ini file first. Check key vimbadmin_plugins.MailboxAutomaticAliases.defaultMapping."), $mailbox));
+                     return false;
+                 }
+             }
+         }
+         return true;
+     }
+
  }

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -82,6 +82,7 @@
 
      /**
       * Check if the aliases is allowed to be removed. If not return false, else return true.
+      * Check if the alias is used as administrative destination and if yes deny removal.
       *
       * @param $controller
       * @param $options
@@ -102,6 +103,8 @@
                  }
              }
          }
+
+         # @TODO Add check for administrative alias removal
          return true;
      }
 
@@ -123,6 +126,7 @@
              }
 
          }
+         # @TODO Check here also for administrative destination alias
         return true;
      }
 

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -91,7 +91,7 @@
              foreach($this->defaultAliases as $key => $item) {
                  if($alias == $item.'@'.$domain) {
                      // not allowed to delete, show error message and stop delete
-                     $controller->addMessage( sprintf( _("Alias %s is required and cannot be deleted."), $alias), OSS_Message::ERROR);
+                     $controller->addMessage( sprintf( _("Alias %s is required and cannot be deleted. See <a href=\"https://www.ietf.org/rfc/rfc2142.txt\" target=\"page\">RFC2142</a>"), $alias), OSS_Message::ERROR);
                      return false;
                  }
              }
@@ -110,7 +110,7 @@
                  foreach($this->defaultAliases as $key => $item) {
                      if($alias == $item.'@'.$domain) {
                          // not allowed to delete, show error message and stop delete
-                         print( sprintf( _("Alias %s is required and cannot be disabled."), $alias));
+                         print( sprintf( _("Alias %s is required and cannot be disabled. See <a href=\"https://www.ietf.org/rfc/rfc2142.txt\" target=\"page\">RFC2142</a>"), $alias));
                          exit(0);
                      }
                  }

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -98,4 +98,24 @@
          }
          return true;
      }
+
+     public function alias_toggleActive_preToggle($controller, $options) {
+         // get alias that should be deleted
+         $alias = $controller->getAlias()->getAddress();
+         $domain = $controller->getDomain()->getDomain();
+
+         if($options['active'] == 'true') {
+             // we have to check if it is allowed to disable this alias
+             if($this->defaultAliases) {
+                 foreach($this->defaultAliases as $key => $item) {
+                     if($alias == $item.'@'.$domain) {
+                         // not allowed to delete, show error message and stop delete
+                         return( sprintf( _("Alias %s is required and cannot be disabled."), $alias));
+                     }
+                 }
+             }
+
+         }
+        return 'ok';
+     }
  }

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -38,7 +38,13 @@
          // read config parameters
          $this->defaultAliases = $controller->getOptions()['vimbadmin_plugins']['MailboxAutomaticAliases']['defaultAliases'];
      }
-     
+
+     /**
+      * Is called after a mailbox is created. It ensures that required aliases are created.
+      *
+      * @param $controller
+      * @param $options
+      */
      public function mailbox_add_addPostflush($controller, $options) {
          // get domain
          $domainId = $controller->getDomain()->getId();
@@ -66,5 +72,30 @@
                  }
              }
          }
+     }
+
+     /**
+      * Check if the aliases is allowed to be removed. If not return false, else return true.
+      *
+      * @param $controller
+      * @param $options
+      * @return bool
+      */
+     public function alias_delete_preRemove($controller, $options) {
+         // get alias that should be deleted
+         $alias = $controller->getAlias()->getAddress();
+         $domain = $controller->getDomain()->getDomain();
+
+         // check if the alias to delete is not enforced by the plugin
+         if($this->defaultAliases) {
+             foreach($this->defaultAliases as $key => $item) {
+                 if($alias == $item.'@'.$domain) {
+                     // not allowed to delete, show error message and stop delete
+                     $controller->addMessage( sprintf( _("Alias %s is required and cannot be deleted."), $alias), OSS_Message::ERROR);
+                     return false;
+                 }
+             }
+         }
+         return true;
      }
  }

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -31,12 +31,14 @@
  */
  class ViMbAdminPlugin_MailboxAutomaticAliases extends ViMbAdmin_Plugin implements OSS_Plugin_Observer {
     private $defaultAliases;
-     
+    private $defaultMapping;
+
      public function __construct(OSS_Controller_Action $controller) {
          parent::__construct($controller, get_class() );
 
          // read config parameters
          $this->defaultAliases = $controller->getOptions()['vimbadmin_plugins']['MailboxAutomaticAliases']['defaultAliases'];
+         $this->defaultMapping = $controller->getOptions()['vimbadmin_plugins']['MailboxAutomaticAliases']['defaultMapping'];
      }
 
      /**
@@ -60,7 +62,11 @@
                  if(count($aliasList) == 0) {
                      $alias = new \Entities\Alias();
                      $alias->setAddress($item.'@'.$domain);
-                     $alias->setGoto($mailbox);
+                     if($this->defaultMapping[$item]) {
+                        $alias->setGoto($this->defaultMapping[$item]);
+                     } else {
+                         $alias->setGoto($mailbox);
+                     }
                      $alias->setDomain($controller->getDomain());
                      $alias->setActive(1);
                      $alias->setCreated(new \DateTime());
@@ -68,7 +74,7 @@
                      // Increase alias count for domain
                      $controller->getDomain()->increaseAliasCount();
                      $controller->getD2EM()->flush();
-                     $controller->addMessage( sprintf(_("Auto-Created alias %s@%s -> %s."), $item, $domain, $mailbox));
+                     $controller->addMessage( sprintf(_("Auto-Created alias %s -> %s."), $alias->getAddress(), $alias->getGoto()));
                  }
              }
          }
@@ -141,7 +147,11 @@
                  if(count($aliasList) == 0) {
                      $alias = new \Entities\Alias();
                      $alias->setAddress($item.'@'.$domain);
-                     $alias->setGoto($aliasGoto);
+                     if($this->defaultMapping[$item]) {
+                         $alias->setGoto($this->defaultMapping[$item]);
+                     }else{
+                         $alias->setGoto($aliasGoto);
+                     }
                      $alias->setDomain($controller->getDomain());
                      $alias->setActive(1);
                      $alias->setCreated(new \DateTime());
@@ -149,7 +159,7 @@
                      // Increase alias count for domain
                      $controller->getDomain()->increaseAliasCount();
                      $controller->getD2EM()->flush();
-                     $controller->addMessage( sprintf(_("Auto-Created alias %s@%s -> %s."), $item, $domain, $aliasGoto));
+                     $controller->addMessage( sprintf(_("Auto-Created alias %s -> %s."), $alias->getAddress(), $alias->getGoto()));
                  }
              }
          }


### PR DESCRIPTION
A plugin that will create required aliases if a mailbox for a domain is created.
Plugin is by default disabled and has to be enabled in application.ini.
Also define default aliases that should be created, see application.ini.dist for an example.
