### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: php
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7
+  - hhvm
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
+  fast-finish: true
+
+install:
+  - composer install
+
+before_script:
+  - export PATH="$TRAVIS_BUILD_DIR/bin:$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
+
+script:
+  - find . -not \( -path './vendor' -prune \) -type f -name '*.php' -print0 | xargs -0 -I file php -l file > /dev/null
+
+sudo: false
+


### PR DESCRIPTION
see https://en.wikipedia.org/wiki/Travis_CI for basic information about [Travis CI](https://travis-ci.org/)

You can do absolutely amazing things with Travis (e.g. checking coding standards, running unit tests, auto-deployment of releases, updating phpDocumentor class docs, updating the project's website ...), the most basic thing Travis can do for you is checking that you don't have PHP syntax errors in your code.

This PR adds a `.travis.yml` doing just this: It checks all PHP files of ViMbAdmin for syntax errors with PHP 5.4, 5.5, 5.6, 7.0, HHVM and PHP's current nightly build. If one of them fail (except the nightly build), GitHub will show a appropriate failure message near the commit or PR that was checked (see https://blog.travis-ci.com/2012-09-04-pull-requests-just-got-even-more-awesome/).

Example build: https://travis-ci.org/PhrozenByte/ViMbAdmin/builds/122607730

Here's a step-by-step tutorial on how to enable Travis for your GitHub repo:
- Go to https://travis-ci.org/ and authenticate using GitHub.
- Go to the profile page (https://travis-ci.org/profile/opensolutions) and enable the ViMbAdmin repo. The repo may not be visible immediately (there's a yellow "Syncing from GitHub" badge on the top of the page), just refresh after a short period of time, giving Travis the chance to fetch all repos from GitHub.
- Click on the settings icon next to the enable button and enable the "Build only if .travis.yml is present" option. Make sure both the "Build pushes" and "Build pull requests" options are enabled.
- Merge this PR :wink:

If you want to add more functionality to Travis, just ask me :smiley:

btw: The reason why I suggest this is because I was wondering with which version PHP introduced [array dereferencing](https://secure.php.net/manual/en/migration54.new-features.php) (idefix6 used it in his new plugin and I falsely thought it has been introduced with PHP 5.5). You will never have to think about something like this with Travis :wink:
