### PR TITLE
remove default timezone in vimbtool

### DIFF
--- a/bin/vimbtool.php
+++ b/bin/vimbtool.php
@@ -5,6 +5,11 @@
  * CLI script
  */
 
+// Set UTC time zone if none set in cli php.ini
+if(!ini_get('date.timezone')) {
+    date_default_timezone_set('UTC');
+}
+
 require_once( dirname( __FILE__ ) . '/../vendor/autoload.php' );
 require_once( dirname( __FILE__ ) . '/utils.inc' );
 //define( 'APPLICATION_ENV', scriptutils_get_application_env() );

--- a/bin/vimbtool.php
+++ b/bin/vimbtool.php
@@ -5,11 +5,7 @@
  * CLI script
  */
 
-// Set UTC time zone if none set in cli php.ini
-if(!ini_get('date.timezone')) {
-    date_default_timezone_set('UTC');
-}
-
+date_default_timezone_set(@date_default_timezone_get());
 require_once( dirname( __FILE__ ) . '/../vendor/autoload.php' );
 require_once( dirname( __FILE__ ) . '/utils.inc' );
 //define( 'APPLICATION_ENV', scriptutils_get_application_env() );

--- a/bin/vimbtool.php
+++ b/bin/vimbtool.php
@@ -5,7 +5,6 @@
  * CLI script
  */
 
-date_default_timezone_set('Europe/Dublin');
 require_once( dirname( __FILE__ ) . '/../vendor/autoload.php' );
 require_once( dirname( __FILE__ ) . '/utils.inc' );
 //define( 'APPLICATION_ENV', scriptutils_get_application_env() );


### PR DESCRIPTION
Default timezone parameter in vimbtool always overwrote CLIs php.ini setting to "Europe/Dublin".
This fixes #186.