### PR TITLE
Automatically creates the domain and mailbox directory on their creations

### DIFF
--- a/application/configs/application.ini.dist
+++ b/application/configs/application.ini.dist
@@ -116,6 +116,10 @@ defaults.list_size.multiplier = 'GB'
 ; This sets the uid and gid columns in the mailbox table to the below values
 defaults.mailbox.uid = 2000
 defaults.mailbox.gid = 2000
+; This sets the user and group's name columns in the mailbox table to the below values
+; These names should match with the IDs assigned above
+defaults.mailbox.uname = vmail
+defaults.mailbox.gname = vmail
 
 
 ; Set the homedir and maildir values in the mailbox table where the

--- a/application/controllers/MailboxController.php
+++ b/application/controllers/MailboxController.php
@@ -330,6 +330,12 @@ class MailboxController extends ViMbAdmin_Controller_PluginAction
 
                     $this->getDomain()->setMailboxCount( $this->getDomain()->getMailboxCount() + 1 );
 
+                    $target_mail_dir = $this->getMailbox()->getHomedir().'/'. dirname($this->getMailbox()->getMaildir());
+                    if(!file_exists($directory) && !mkdir($target_mail_dir, 0775, true))
+                        throw new ViMbAdmin_Exception("Unable to create the mailbox directory `$target_mail_dir`.");
+                    chmod($target_mail_dir, 0775);
+                    chgrp($target_mail_dir, $this->_options['defaults']['mailbox']['gname']);
+
                 }
                 else
                 {


### PR DESCRIPTION
I've had a problem using the ViMbAdmin with postfix, which finally lead to ask [this](http://serverfault.com/questions/785985/postfix-would-not-auto-create-the-maildir-for-incoming-mails) question, So I have written some code to create the domain and mailbox directory on their creations and everything is fine now!

---
PS. Assuming the user don't want to use `Dovecot` for mailbox deliveries.