### PR TITLE
Disallow non-super admins to add/edit domains

### DIFF
--- a/application/controllers/DomainController.php
+++ b/application/controllers/DomainController.php
@@ -197,6 +197,8 @@ class DomainController extends ViMbAdmin_Controller_PluginAction
                 ->removeValidator( 'OSSDoctrine2Uniqueness' );
         }
 
+        $this->authorise( true ); // must be a super admin
+
         $this->view->quota_multiplier = $form->getFilterFileSizeMultiplier();
 
         $this->view->domain = $this->getDomain();

--- a/application/views/domain/list.phtml
+++ b/application/views/domain/list.phtml
@@ -67,9 +67,11 @@
                 <td>{$domain.created->format( 'Y-m-d' )}</td>
                 <td>
                     <div class="btn-group">
-                        <a class="btn btn-mini have-tooltip" id="edit_domain_{$domain.id}" title="Edit" href="{genUrl controller='domain' action='edit' did=$domain.id}">
-                            <i class="icon-pencil"></i>
-                        </a>
+                        {if $user->isSuper()}
+                            <a class="btn btn-mini have-tooltip" id="edit_domain_{$domain.id}" title="Edit" href="{genUrl controller='domain' action='edit' did=$domain.id}">
+                                <i class="icon-pencil"></i>
+                            </a>
+                        {/if}
                         {if isset( $domain_actions ) }
                             {assign var=oid value=$mbox.id}
                             {foreach $domain_actions as $action}


### PR DESCRIPTION
Non-super admins simply don't have to visit the domain edit page. The only option non-super admins have write access to, is `toggle-active`. However, this option is already accessibly through the AJAX toggle button on the domain list page. The easiest solution is therefore to disallow navigating to the add (btw, non-super admins were able to create domains until now, however, they weren't able to assign admins to domains) and edit page.

Fixes #30, #181