### PR TITLE
Added table of contents and reordered email settings text to make it more clear

### DIFF
--- a/application/views/mailbox/email/settings.phtml
+++ b/application/views/mailbox/email/settings.phtml
@@ -10,7 +10,10 @@ Your email address is: {$mailbox->getUsername()}
 Your password is: {$password}
 {/if}
 
-Access to your mail can be configured using the settings below.
+In this e-mail you will find:
+- A way to change your password
+- A way to contact for assistance
+- Settings for you to access your Email.
 
 If you want to change your password, you may do so at:
 
@@ -20,7 +23,7 @@ For assistance, please contact:
 
   {$settings.email.name} <{$settings.email.address}>
 
-
+Access to your mail can be configured using the settings below.
 
 
 {if $settings.webmail.enabled}


### PR DESCRIPTION
Given the extent of the settings email, users may need to scroll, and so miss part of the email text. Adding a table of contents helps reader to be aware what the email content is.

Also, the "check settings below" line is more effective after the password change message, as the reader will be able to understand what the sentence refers too (which is not the password change as it may be lead to believe with current text)

I agree to the [Contributor License Agreement](https://github.com/opensolutions/ViMbAdmin/wiki/Contributor-License-Agreement)

@pierreozoux check this out.