### PR TITLE
Use DIRECTORY_SEPARATOR instead of DS

### DIFF
--- a/library/ViMbAdmin/Smarty/functions/modifier.date_formatter.php
+++ b/library/ViMbAdmin/Smarty/functions/modifier.date_formatter.php
@@ -43,8 +43,9 @@ function smarty_modifier_date_formatter($string, $format=null, $default_date='',
     } else {
         return;
     }
+
     if ($formatter=='strftime'||($formatter=='auto'&&strpos($format,'%')!==false)) {
-        if (DS == '\\') {
+        if (DIRECTORY_SEPARATOR == '\\') {
             $_win_from = array('%D', '%h', '%n', '%r', '%R', '%t', '%T');
             $_win_to = array('%m/%d/%y', '%b', "\n", '%I:%M:%S %p', '%H:%M', "\t", '%H:%M:%S');
             if (strpos($format, '%e') !== false) {


### PR DESCRIPTION
The smarty_modifier_date_formatter function uses system path
to determine if the target OS is Windows.

PHP 4 introduced DIRECTORY_SEPARATOR, and DS isn't defined in
the current configuration and Smarty bootstrap process.

It so seems safe to switch to DIRECTORY_SEPARATOR.

Fixes #217.