### PR TITLE
Change redirection for changed password

### DIFF
--- a/application/controllers/AuthController.php
+++ b/application/controllers/AuthController.php
@@ -135,7 +135,7 @@ class AuthController extends ViMbAdmin_Controller_Action
 
                     $this->getD2EM()->flush();
                     $this->addMessage( _( 'You have successfully changed your password.' ), OSS_Message::SUCCESS );
-                    $this->_redirect( 'auth/login' );
+                    $this->_redirect( 'auth/change-password' );
                 }
                 else
                     $this->addMessage( _( 'Invalid username or password.' ), OSS_Message::ERROR );


### PR DESCRIPTION
Given I am a normal user
I don't have a vimbadmin account, but just a regular email account
I was given the link `auth/change-password` to change my password.
Once I changed my password, I am currently redirected to the login page.
So as a user, I try to login, but I'm not a vimbadmin user, so I don't usnderstand why my login/password doesn't work.

To fix that, if we redirect to the change-password page, there will be no confusion (or at least, less).

Fix #191 