### PR TITLE
Don't expose ViMbAdmin's patch level in the footer

### DIFF
--- a/application/views/_skins/myskin/footer.phtml
+++ b/application/views/_skins/myskin/footer.phtml
@@ -19,12 +19,14 @@ benefit from this application.
 
     <div id="modal_dialog" class="modal hide fade"> </div>
     <footer>
+
         <p>
             Copyright &copy; 2011 - {$smarty.now|date_formatter:"%Y"} <a href="http://www.opensolutions.ie/" target="_blank" title="Open Source Solutions Limited">Open Source Solutions Limited</a>.
             This Program is provided AS IS, without warranty.
         </p>
         <p>
-            <a href="https://github.com/opensolutions/ViMbAdmin/wiki">ViMbAdmin V{ViMbAdmin_Version::VERSION}</a>.
+            <a href="http://www.vimbadmin.net/">ViMbAdmin</a>
+                <a href="https://github.com/opensolutions/ViMbAdmin/releases">v{ViMbAdmin_Version::MILESTONE}</a>.
             Licensed under the <a href="http://www.gnu.org/licenses/gpl-3.0-standalone.html" target="_blank" title="GNU GPL v3">
                 GNU General Public License V3
             </a>.
@@ -40,8 +42,8 @@ benefit from this application.
             <span class="label label-info">
                 <a class="aplain" href="https://github.com/opensolutions/ViMbAdmin">GitHub</a>
             </span>
-        	&nbsp;|&nbsp;
-        	Learn more about
+            &nbsp;|&nbsp;
+            Learn more about
             <span class="label label-info">
                 <a class="aplain" href="http://www.opensolutions.ie/">Open Solutions</a>
             </span>

--- a/application/views/footer.phtml
+++ b/application/views/footer.phtml
@@ -57,15 +57,6 @@ benefit from this application.
             <span class="label label-info">
                 <a class="aplain" href="http://www.opensolutions.ie/">Open Solutions</a>
             </span>
-            &nbsp;|&nbsp;
-            <span class="label label-info">
-                <a class="aplain" href="https://groups.google.com/forum/#!forum/vimbadmin-announce">Announcements</a>
-            </span>
-            and
-            <span class="label label-info">
-                <a class="aplain" href="https://groups.google.com/forum/#!forum/vimbadmin-discuss">Discussion</a>
-            </span>
-            Mailing Lists
     	</p>
 
 

--- a/application/views/footer.phtml
+++ b/application/views/footer.phtml
@@ -36,7 +36,7 @@ benefit from this application.
         </p>
         <p>
             <a href="http://www.vimbadmin.net/">ViMbAdmin</a>
-                <a href="https://github.com/opensolutions/ViMbAdmin/releases">V{ViMbAdmin_Version::VERSION}</a>.
+                <a href="https://github.com/opensolutions/ViMbAdmin/releases">v{ViMbAdmin_Version::MILESTONE}</a>.
             Licensed under the <a href="http://www.gnu.org/licenses/gpl-3.0-standalone.html" target="_blank" title="GNU GPL v3">
                 GNU General Public License V3
             </a>.

--- a/library/ViMbAdmin/Version.php
+++ b/library/ViMbAdmin/Version.php
@@ -49,6 +49,14 @@ final class ViMbAdmin_Version
     const VERSION = '3.3.0';
 
     /**
+     * Version milestone
+     *
+     * The version milestone is used to publicly identify the running version
+     * and should therefore not include the patch level.
+     */
+    const MILESTONE = '3.3';
+
+    /**
      * Database schema version
      */
     const DBVERSION = 1;


### PR DESCRIPTION
Exposing the exact patch level allows attackers to easily identify likely vulnerable instances of ViMbAdmin if a security flaw happens to be found. This commit simply replaces the exact version string ('3.3.0') with the milestone version string ('3.3') in ViMbAdmin's footer. See 013cfec60b4900c661e1cc75b20d28b6a377f8ee

Additional changes:
* [Remove abandoned Google Groups links from footer](https://github.com/opensolutions/ViMbAdmin/commit/9dd4d8247a85a11e404b09b852838f9037aa450e): If Google Groups or any other kind of forum is revived, one should probably rather add the links to ViMbAdmin's website and the GitHub repo instead, not include it in the footer of every single ViMbAdmin instance.
* [Sync footer of 'myskin' template with default footer](https://github.com/opensolutions/ViMbAdmin/commit/935c212d775ecf6908892c8932e7bfb0c01753e2)