### PR TITLE
Bump Doctrine ORM to last 2.x version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     ],
     "require": {
         "php": ">=8.0.0",
-        "doctrine/orm": "2.8.*",
+        "doctrine/cache": "1.13.*",
+        "doctrine/orm": "2.19.*",
         "shardj/zf1-future": "1.*",
         "smarty/smarty": "~4.3.0"
     },


### PR DESCRIPTION
Doctrine ORM 2.8 isn't compatible with PHP 8.3. The project offers warranties against breaking compatibility in the 2.x series, so it's a straightforward version bump without any need for code change.

Doctrine Cache library is used with concrete adapters like ArrayCache or MemcacheCache. They're only included in the 1.x branch and removed from 2.x. While Doctrine ORM is happy with both versions, it will get the most recent Doctrine Cache by default.