### PR TITLE
Explicitly give current class for get_class

### DIFF
--- a/application/plugins/AccessPermissions.php
+++ b/application/plugins/AccessPermissions.php
@@ -50,7 +50,7 @@ class ViMbAdminPlugin_AccessPermissions extends ViMbAdmin_Plugin implements OSS_
 
     public function __construct( OSS_Controller_Action $controller )
     {
-        parent::__construct( $controller, get_class() );
+        parent::__construct( $controller, get_class( $this ) );
         
         // no setup tasks are required
         //

--- a/application/plugins/AdditionalInfo.php
+++ b/application/plugins/AdditionalInfo.php
@@ -43,7 +43,7 @@ class ViMbAdminPlugin_AdditionalInfo extends ViMbAdmin_Plugin implements OSS_Plu
 
     public function __construct( OSS_Controller_Action $controller )
     {
-        parent::__construct( $controller, get_class() );
+        parent::__construct( $controller, get_class( $this ) );
         
         // no setup tasks are required
         //

--- a/application/plugins/DirectoryEntry.php
+++ b/application/plugins/DirectoryEntry.php
@@ -44,7 +44,7 @@ class ViMbAdminPlugin_DirectoryEntry extends ViMbAdmin_Plugin implements OSS_Plu
 
     public function __construct( OSS_Controller_Action $controller )
     {
-        parent::__construct( $controller, get_class() );
+        parent::__construct( $controller, get_class( $this ) );
         
         // no setup tasks are required
         //

--- a/application/plugins/MailboxAutomaticAliases.php
+++ b/application/plugins/MailboxAutomaticAliases.php
@@ -74,7 +74,7 @@ class ViMbAdminPlugin_MailboxAutomaticAliases extends ViMbAdmin_Plugin implement
 
     public function __construct( OSS_Controller_Action $controller )
     {
-        parent::__construct( $controller, get_class() );
+        parent::__construct( $controller, get_class( $this ) );
 
         // read config parameters
         $this->defaultAliases = isset( $controller->getOptions()['vimbadmin_plugins']['MailboxAutomaticAliases']['defaultAliases'] )


### PR DESCRIPTION
Calling get_class() without an argument in PHP 8.3+ emits E_DEPRECATED.