### PR TITLE
[FIX] Postgresql database creation

### DIFF
--- a/doctrine2/ViMbAdmin.ormdesigner
+++ b/doctrine2/ViMbAdmin.ormdesigner
@@ -48,7 +48,7 @@
       <field name="active" type="boolean" default="1" required="true" uuid="e7edc5a1-a302-489a-bfbc-b65f16dd1e73"/>
       <field name="created" type="datetime" required="true" uuid="9c9200e4-08e2-4428-a653-c4bd38745977"/>
       <field name="modified" type="datetime" uuid="720dced4-fc3e-44c4-8a53-9c64eb3ae872"/>
-      <index name="IX_Username_1" unique="true">
+      <index name="IX_Username_admin" unique="true">
         <index-field name="username"/>
       </index>
       <orm-attributes>

--- a/doctrine2/xml/Entities.Admin.dcm.xml
+++ b/doctrine2/xml/Entities.Admin.dcm.xml
@@ -19,7 +19,7 @@
     <field name="created" type="datetime" nullable="false"/>
     <field name="modified" type="datetime" nullable="true"/>
     <unique-constraints>
-      <unique-constraint name="IX_Username_1" columns="username"/>
+      <unique-constraint name="IX_Username_admin" columns="username"/>
     </unique-constraints>
     <one-to-many field="Preferences" target-entity="Entities\AdminPreference" mapped-by="Admin"/>
     <one-to-many field="Logs" target-entity="Entities\Log" mapped-by="Admin"/>

--- a/doctrine2/xml/Entities.Mailbox.dcm.xml
+++ b/doctrine2/xml/Entities.Mailbox.dcm.xml
@@ -39,7 +39,7 @@
     <field name="created" type="datetime" nullable="false"/>
     <field name="modified" type="datetime" nullable="true"/>
     <unique-constraints>
-      <unique-constraint name="IX_Username_1" columns="username"/>
+      <unique-constraint name="IX_Username_mailbox" columns="username"/>
     </unique-constraints>
     <many-to-one field="Domain" target-entity="Entities\Domain" inversed-by="Mailboxes">
       <join-columns>


### PR DESCRIPTION
When trying to create the database with postgresql as a backend, an error occurs due to some indexes sharing names.
Postgres and mysql handle indexes differently, an index in postgres uses the same namespace as the tables. 
This MR aims at fixing the issue, the fix is quite simple and should not have any side effect.

fixes #308